### PR TITLE
Fix different png images getting same hash.

### DIFF
--- a/src/Cpdf.php
+++ b/src/Cpdf.php
@@ -3798,7 +3798,7 @@ class Cpdf
         }
 
         if ($this->hashed) {
-            $oHash = md5($iChunk['idata']);
+            $oHash = md5($data);
         }
         if (isset($oHash) && isset($this->objectHash[$oHash])) {
             $label = $this->objectHash[$oHash];


### PR DESCRIPTION
If png images with the same size but different
content using only black on a transparent
background the first included image replaces all
subsequent images even if different since they get
the same hash because idata string is the same.

Creating the hash from the actual content of the
file instead of idata fixes this issue.