### PR TITLE
Initialize $offset variables on function ezImage()

### DIFF
--- a/src/Cezpdf.php
+++ b/src/Cezpdf.php
@@ -1886,6 +1886,7 @@ class Cezpdf extends Cpdf
      */
     public function ezImage($image, $pad = 5, $width = 0, $resize = 'full', $just = 'center', $angle = 0, $border = '')
     {
+        $offset=0;
         $temp = false;
         //beta ezimage function
         if (stristr($image, '://')) { //copy to temp file


### PR DESCRIPTION
Without this change, sometimes will throw this error:

`Error:(Notice) [Undefined variable: offset] (Num 8) en el fichero: [E:\Inet\php\php7\CezPDF\GitHub\src\Cezpdf.php] (Linea: 1959)`

Tested on PHP7 with E_STRICT enabled