### PR TITLE
Corregir error de la funcion addJpegFromFile() (Solved function error addJpegFromFile() )

### DIFF
--- a/src/Cpdf.php
+++ b/src/Cpdf.php
@@ -3809,8 +3809,8 @@ class Cpdf
     {
         // attempt to add a jpeg image straight from a file, using no GD commands
         // note that this function is unable to operate on a remote file.
-
-        if (!file_exists($img)) {
+        $var = file_get_contents($img);
+        if ( $var == false ) {
             return;
         }
 


### PR DESCRIPTION
Solventado el problema al intentar cargar una imagen tipo **.JPG** en el documento **PDF** ya que al intentarlo varias veces no se mostraba la imagen a pesar de que la ruta era la correcta.

Solved bug to function addJpegFromFile() when not load images into PDF document.