### PR TITLE
Little fix while generating some PDF

### DIFF
--- a/src/Cezpdf.php
+++ b/src/Cezpdf.php
@@ -669,7 +669,7 @@ class Cezpdf extends Cpdf
      *
      * @return int count of ez['pageNumbering']
      */
-    public function ezStartPageNumbers($x, $y, $size, $pos = 'left', $pattern = '{PAGENUM} of {TOTALPAGENUM}', $num = '')
+    public function ezStartPageNumbers($x, $y, $size, $pos = 'left', $pattern = '{PAGENUM} of {TOTALPAGENUM}', $num = 1)
     {
         if (!$pos || !strlen($pos)) {
             $pos = 'left';
@@ -1541,7 +1541,7 @@ class Cezpdf extends Cpdf
 
                         // decide which color to use!
                         // specified for the cell is first choice
-                    if (count($fillColor) && is_array($fillColor)) {
+                    if ($fillColor && count($fillColor) && is_array($fillColor)) {
                         $rowColShading[] = array('x' => $rowX, 'y' => $rowY, 'width' => $rowW, 'color' => $fillColor);
                     } // color of the column is second choice
                     elseif (isset($options['cols']) && isset($options['cols'][$colName]) && isset($options['cols'][$colName]['bgcolor']) && is_array($options['cols'][$colName]['bgcolor'])) {


### PR DESCRIPTION
This fixes some issues when generating some PDF.

- L672: $num is defined in PHPDoc has int, but default value was an empty string. Without this change, pagination is always 0 of 0 when this parameter is not specified by default.
- L1544: An empty string is not array or countable. Without this change, it was outputing warning messages like this: Warning: count(): Parameter must be an array or an object that implements Countable in vendor/rospdf/pdf-php/src/Cezpdf.php on line 1544. Maybe is a better solution replace '$fillColor && ' by '!empty($fillColor) && '.