### PR TITLE
Fix deprecated usage of hexdec with invalid chars

### DIFF
--- a/src/Cpdf.php
+++ b/src/Cpdf.php
@@ -2017,7 +2017,7 @@ class Cpdf
                                 $width = floatval($m[2]);
 
                                 if ($c >= 0) {
-                                    if ($c != hexdec($n)) {
+                                    if (!preg_match('/^[a-f0-9]+$/i', $n) || $c != hexdec($n)) {
                                         $cachedFont['codeToName'][$c] = $n;
                                     }
                                     $cachedFont['C'][$c] = $width;


### PR DESCRIPTION
On PHP 7.4, passing a string that is not an hex chain to `hexdec` is deprecated.

```
PHP Deprecated function: Invalid characters passed for attempted conversion, these have been ignored in ./vendor/rospdf/pdf-php/src/Cpdf.php at line 2020
```