### PR TITLE
License for Adobe Postscript AFM was missing

### DIFF
--- a/src/fonts/AdobePostscriptAFM.license.txt
+++ b/src/fonts/AdobePostscriptAFM.license.txt
@@ -1,0 +1,17 @@
+== License Notes ==
+This license was identified as part of the halibut package. It is Free and GPL-Compatible.
+
+Please use: License: APAFML
+
+== License Text ==
+  Copyright (c) 1985, 1987, 1989, 1990, 1991, 1992, 1993, 1997
+  Adobe Systems Incorporated.  All Rights Reserved.
+
+  This file and the 14 PostScript(R) AFM files it accompanies may be
+  used, copied, and distributed for any purpose and without charge,
+  with or without modification, provided that all copyright notices
+  are retained; that the AFM files are not distributed without this
+  file; that all modifications to this file or any of the AFM files
+  are prominently noted in the modified file(s); and that this
+  paragraph is not modified. Adobe Systems has no responsibility or
+  obligation to support the use of the AFM files.


### PR DESCRIPTION
The attached AFM files requires this license, as stated in the license: "that the AFM files are not distributed without this file".