### PR TITLE
Fix PHP 8.1 conversion from float deprecation

### DIFF
--- a/src/include/TTF.php
+++ b/src/include/TTF.php
@@ -1115,7 +1115,7 @@ class TTF
 
     private static function setUshort(&$b, &$off, $val)
     {
-        $b[$off++] = chr((int) $val / 256);
+        $b[$off++] = chr((int) ($val / 256));
         $b[$off++] = chr($val % 256);
     }
 


### PR DESCRIPTION
Introduced in #164, we continue to get the "Implicit conversion from float deprecation" message.

```
PHP Deprecated:  Implicit conversion from float 0.3125 to int loses precision
in vendor/rospdf/pdf-php/src/include/TTF.php on line 1118
```