### PR TITLE
Fix for php8.2 compatibility

### DIFF
--- a/src/Cpdf.php
+++ b/src/Cpdf.php
@@ -2993,7 +2993,7 @@ class Cpdf
         }
 
         if (mb_detect_encoding($text) != 'UTF-8') {
-            $text = utf8_encode($text);
+            $text = mb_convert_encoding($text, 'UTF-8');
         }
 
         $orgWidth = $width;


### PR DESCRIPTION
utf8_encode function has been deprecated in PHP 8.2